### PR TITLE
oox::node, refactored examples, extended examples and benchmarks

### DIFF
--- a/examples/fibonacci.h
+++ b/examples/fibonacci.h
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <oox/oox.h>
+
+namespace Fibonacci {
+namespace Serial { // Original problem statement
+
+    int Fib(volatile int n) {
+        if(n < 2) return n;
+        return Fib(n-1) + Fib(n-2);
+    }
+
+}
+namespace OOX1 { // Concise 2 lines OOX demonstration
+
+    oox::var<int> Fib(int n) {
+        if(n < 2) return n;
+        return oox::run(std::plus<int>(), oox::run(Fib, n-1), oox::run(Fib, n-2) );
+    }
+
+}
+namespace OOX2 { // Optimized number and order of tasks
+
+    oox::var<int> Fib(int n) {                                         // OOX: High-level continuation style
+        if(n < 2) return n;
+        auto right = oox::run(Fib, n-2);                               // spawn right child
+        return oox::run(std::plus<int>(), Fib(n-1), std::move(right)); // assign continuation
+    }
+
+}}

--- a/examples/filesystem.h
+++ b/examples/filesystem.h
@@ -1,0 +1,94 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <oox/oox.h>
+
+namespace Filesystem {
+
+struct INode {
+    int v;
+    bool is_file() { return v>7; }
+    size_t size()  { return v; }
+    INode* begin() { return this+1; }
+    INode* end()   { return this+1+v; }
+} tree[]{4,2,3,8,9,10};
+
+namespace Serial {
+
+size_t disk_usage(INode& node) {
+    if (node.is_file())
+        return node.size();
+    size_t sum = 0;
+    for (auto &subnode : node)
+        sum += disk_usage(subnode);
+    return sum;
+}
+
+}
+namespace Simple {
+
+oox::var<size_t> disk_usage(INode& node)
+{
+    if (node.is_file())
+        return node.size();
+    oox::var<size_t> sum = 0;
+    for (auto &subnode : node)
+        oox::run([](size_t &sm, // serialized on write operation
+                 size_t sz){ sm += sz; }, sum, oox::run(disk_usage, std::ref(subnode))); // parallel recursive leaves
+    return sum;
+}
+
+}//namespace Filesystem::Simple
+#if HAVE_TBB
+}//namespace Filesystem
+
+#include <tbb/concurrent_vector.h>
+#include <functional>
+#include <numeric>
+#include <vector>
+
+namespace Filesystem {
+namespace AntiDependence {
+
+oox::var<size_t> disk_usage(INode& node)
+{
+    if (node.is_file())
+        return node.size();
+    typedef tbb::concurrent_vector<size_t> cv_t;
+    typedef cv_t *cv_ptr_t;
+    oox::var<cv_ptr_t> resv = new cv_t;
+    for (auto &subnode : node)
+        oox::run([](const cv_ptr_t &v, // make it read-only (but not copyable) and thus parallel
+                            size_t s){ v->push_back(s); }, resv, oox::run(disk_usage, std::ref(subnode)));
+    return oox::run([](cv_ptr_t &v) { // make it read-write to induce anti-dependence from the above read-only tasks
+        size_t res = std::accumulate(v->begin(), v->end(), 0);
+        delete v; v = nullptr;      // release memory, reset the pointer
+        return res;
+    }, resv);
+}
+
+}//namespace Filesystem::AntiDependence
+namespace Extended {
+#if 0
+oox::var<size_t> disk_usage(INode &node)
+{
+    if (node.is_file())
+        return node.size();
+    typedef tbb::concurrent_vector<size_t> cv_t;
+    cv_t *v = new cv_t;
+    std::vector<oox::node> tasks;
+    for (auto &subnode : *node)
+        tasks.push_back(oox::run( [v](size_t s){ v->push_back(s); }, oox::run(disk_usage, std::ref(subnode))) );
+    auto join_node = oox::join( tasks.begin(), tasks.end() );
+    return oox::run( join_node,              // use explicit flow-dependence
+        [v]{
+            size_t res = std::accumulate(v->begin(), v->end(), 0);
+            delete v;                       // release memory
+            return res;
+        });
+}
+#endif
+}//namespace Filesystem::Extended
+#endif // HAVE_TBB
+}//namespace Filesystem

--- a/examples/wavefront.h
+++ b/examples/wavefront.h
@@ -1,0 +1,92 @@
+// Copyright (C) 2021 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <oox/oox.h>
+
+namespace Wavefront_LCS {
+
+static const int MAX_LEN = 200;
+const char input1[] = "has 10000 line input, and each line has ave 3000 chars (include space). It took me  50 mins to find lcs. the requirement is not exceed 5 mins.";
+const char input2[] = "has 100 line input, and each line has ave 60k chars. It never finish running";
+
+namespace Serial {
+int LCS( const char* x, size_t xlen, const char* y, size_t ylen )
+{
+    int F[MAX_LEN+1][MAX_LEN+1];
+
+    for( size_t i=1; i<=xlen; ++i )
+        for( size_t j=1; j<=ylen; ++j )
+            F[i][j] = x[i-1]==y[j-1] ? F[i-1][j-1]+1 : std::max(F[i][j-1],F[i-1][j]);
+    return F[xlen][ylen];
+}}
+
+namespace Straight {
+int LCS( const char* x, size_t xlen, const char* y, size_t ylen )
+{
+    auto F = new oox::var<int>[MAX_LEN+1][MAX_LEN+1];
+    oox::var<int> zero(0);
+    auto f = [x,y,xlen,ylen](int i, int j, int F11, int F01, int F10) {
+        return x[i-1]==y[j-1] ? F11+1 : std::max(F01, F10);
+    };
+
+    for( size_t i=1; i<=xlen; ++i )
+        for( size_t j=1; j<=ylen; ++j )
+            F[i][j] = std::move(oox::run(f, i, j, i+j==0?zero:F[i-1][j-1], j==0?zero:F[i][j-1], i==0?zero:F[i-1][j]));
+
+    auto r = oox::wait_and_get(F[xlen][ylen]);
+    delete [] F;
+    return r;
+}
+
+}
+
+#if 0 // TODO: HAVE_TBB
+} //namespace Wavefront_LCS
+#include <tbb/blocked_range2d.h>
+#include <algorithm>
+namespace Wavefront_LCS {
+
+struct Range2D : tbb::blocked_range2d<int,int> {
+    using tbb::blocked_range2d<int,int>::blocked_range2d;
+    bool is_divisible4() {
+        return rows().is_divisible() && cols().is_divisible();
+    }
+    Range2D quadrant(bool bottom, bool right) {
+        int rmin = rows().begin(), rmax = rows().end(), rmid = (rmin+rmax+1)/2;
+        int cmin = cols().begin(), cmax = cols().end(), cmid = (cmin+cmax+1)/2;
+        return Range2D(bottom?rmid:rmin, bottom?rmax:rmid, rows().grainsize()
+                       ,right?cmid:cmin, right?cmax:cmid, cols().grainsize());
+    }
+};
+
+namespace SimpleRecursive {
+
+struct RecursionBody {
+    int (*F)[MAX_LEN+1];
+    const char *X, *Y;
+    RecursionBody(int f[][MAX_LEN+1], const char* x, const char* y) : F(f), X(x), Y(y) {}
+    oox::node operator()(Range2D r) {
+        if( !r.is_divisible4() ) {
+            for( size_t i=r.rows().begin(), ie=r.rows().end(); i<ie; ++i )
+                for( size_t j=r.cols().begin(), je=r.cols().end(); j<je; ++j )
+                    F[i][j] = X[i-1]==Y[j-1] ? F[i-1][j-1]+1 : std::max(F[i][j-1], F[i-1][j]);
+            return oox::node();
+        }
+        oox::node node00 = oox::run( *this, r.quadrant(0,0) );
+        oox::node node10 = oox::run( *this, r.quadrant(1,0), node00 ); // TODO: implement additional deps for oox_run
+        oox::node node01 = oox::run( *this, r.quadrant(0,1), node00 );
+        return oox::run( *this, r.quadrant(1,1), node10, node01 );
+    }
+};
+
+void LCS( const char* x, size_t xlen, const char* y, size_t ylen ) {
+    int F[MAX_LEN+1][MAX_LEN+1];
+    RecursionBody rf(F, x, y);
+
+    oox::wait_and_get( rf(Range2D(0,xlen,0,ylen)) );
+}
+
+}
+#endif
+}//namespace Wavefront_LCS

--- a/oox/oox.h
+++ b/oox/oox.h
@@ -35,12 +35,12 @@
 namespace oox {
 
 #if OOX_SERIAL_DEBUG //////////////////// Immediate execution //////////////////////////////////
-class oox_node {
-    oox_node &operator=(const oox_node &) = delete;
+class node {
+    node &operator=(const node &) = delete;
 };
 
 template<typename T>
-struct var : public oox_node {
+struct var : public node {
     static_assert(std::is_same<T, typename std::decay<T>::type>::value,
                   "Specialize oox::var only by plain types."
                   "For references, use reference_wrapper,"
@@ -55,7 +55,7 @@ struct var : public oox_node {
 };
 
 template<>
-struct var<void> : public oox_node {
+struct var<void> : public node {
     var() {}
 };
 
@@ -85,9 +85,9 @@ struct gen_oox<var<VT> > {
 };
 template<>
 struct gen_oox<void> {
-    typedef oox_node type;
+    typedef node type;
     template< typename F, typename... Args >
-    static type run(F&& f, Args&&... args) { std::forward<F>(f)(std::forward<Args>(args)...); return oox_node(); }
+    static type run(F&& f, Args&&... args) { std::forward<F>(f)(std::forward<Args>(args)...); return node(); }
 };
 template< typename T> using var_type = typename gen_oox<T>::type;
 
@@ -101,7 +101,7 @@ auto run(F&& f, Args&&... args)->var_type<decltype(f(unoox(std::forward<Args>(ar
 template<typename T>
 T wait_and_get(const var<T> &ov) { return ov.my_value; }
 
-void wait_for_all(oox_node &) {}
+void wait_for_all(node &) {}
 
 #else ///////////////////////////////// Parallel execution  ///////////////////////////////////
 
@@ -670,7 +670,7 @@ public:
     }
 };
 
-typedef var<void> oox_node;
+typedef var<void> node;
 
 namespace internal {
 template< typename T >

--- a/tests/test_oox.cpp
+++ b/tests/test_oox.cpp
@@ -22,6 +22,10 @@ bool g_oox_verbose = false;
 
 /////////////////////////////////////// EXAMPLES ////////////////////////////////////////
 
+#include "../examples/fibonacci.h"
+#include "../examples/filesystem.h"
+#include "../examples/wavefront.h"
+
 namespace ArchSample {
     // example from original OOX
     typedef int T;
@@ -39,178 +43,6 @@ namespace ArchSample {
         return oox::wait_and_get(a);
     }
 }
-
-namespace Fib0 {
-    // Serial
-    int Fib(int n) {
-        if(n < 2) return n;
-        return Fib(n-1) + Fib(n-2);
-    }
-}
-namespace Fib1 {
-    // Concise demonstration
-    oox::var<int> Fib(int n) {
-        if(n < 2) return n;
-        return oox::run(std::plus<int>(), oox::run(Fib, n-1), oox::run(Fib, n-2) );
-    }
-}
-namespace Fib2 {
-    // Optimized number and order of tasks
-    oox::var<int> Fib(int n) {                                         // OOX: High-level continuation style
-        if(n < 2) return n;
-        auto right = oox::run(Fib, n-2);                               // spawn right child
-        return oox::run(std::plus<int>(), Fib(n-1), std::move(right)); // assign continuation
-    }
-}
-
-namespace Filesystem {
-struct INode {
-    int v;
-    bool is_file() { return v>7; }
-    size_t size()  { return v; }
-    INode* begin() { return this+1; }
-    INode* end()   { return this+1+v; }
-} tree[]{4,2,3,8,9,10};
-
-namespace Serial {
-size_t disk_usage(INode& node) {
-    if (node.is_file())
-        return node.size();
-    size_t sum = 0;
-    for (auto &subnode : node)
-        sum += disk_usage(subnode);
-    return sum;
-}
-}
-namespace Simple {
-oox::var<size_t> disk_usage(INode& node)
-{
-    if (node.is_file())
-        return node.size();
-    oox::var<size_t> sum = 0;
-    for (auto &subnode : node)
-        oox::run([](size_t &sm, // serialized on write operation
-                 size_t sz){ sm += sz; }, sum, oox::run(disk_usage, std::ref(subnode))); // parallel recursive leaves
-    return sum;
-}
-}//namespace Filesystem::Simple
-#if 0
-namespace AntiDependence {
-oox::var<size_t> disk_usage(INode& node)
-{
-    if (node.is_file())
-        return node.size();
-    typedef tbb::concurrent_vector<size_t> cv_t;
-    typedef cv_t *cv_ptr_t;
-    oox::var<cv_ptr_t> resv = new cv_t;
-    for (auto &subnode : node)
-        oox::run([](const cv_ptr_t &v, // make it read-only (but not copyable) and thus parallel
-                            size_t s){ v->push_back(s); }, resv, oox::run(disk_usage, std::ref(subnode)));
-    return oox::run([](cv_ptr_t &v) { // make it read-write to induce anti-dependence from the above read-only tasks
-        size_t res = std::accumulate(v->begin(), v->end(), 0);
-        delete v; v = nullptr;      // release memory, reset the pointer
-        return res;
-    }, resv);
-}
-}//namespace Filesystem::AntiDependence
-#endif
-#if 0
-namespace Extended {
-oox::var<size_t> disk_usage(INode &node)
-{
-    if (node.is_file())
-        return node.size();
-    typedef tbb::concurrent_vector<size_t> cv_t;
-    cv_t *v = new cv_t;
-    std::vector<oox_node> tasks;
-    for (auto &subnode : *node)
-        tasks.push_back(oox::run( [v](size_t s){ v->push_back(s); }, oox::run(disk_usage, std::ref(subnode))) );
-    auto join_node = oox_join( tasks.begin(), tasks.end() );
-    return oox::run( join_node,              // use explicit flow-dependence
-        [v]{
-            size_t res = std::accumulate(v->begin(), v->end(), 0);
-            delete v;                       // release memory
-            return res;
-        });
-}
-}//namespace Filesystem::Extended
-#endif
-}//namespace Filesystem
-
-namespace Wavefront_LCS {
-static const int MAX_LEN = 200;
-const char input1[] = "has 10000 line input, and each line has ave 3000 chars (include space). It took me  50 mins to find lcs. the requirement is not exceed 5 mins.";
-const char input2[] = "has 100 line input, and each line has ave 60k chars. It never finish running";
-
-namespace Serial {
-int LCS( const char* x, size_t xlen, const char* y, size_t ylen )
-{
-    int F[MAX_LEN+1][MAX_LEN+1];
-
-    for( size_t i=1; i<=xlen; ++i )
-        for( size_t j=1; j<=ylen; ++j )
-            F[i][j] = x[i-1]==y[j-1] ? F[i-1][j-1]+1 : std::max(F[i][j-1],F[i-1][j]);
-    return F[xlen][ylen];
-}}
-
-namespace Straight {
-int LCS( const char* x, size_t xlen, const char* y, size_t ylen )
-{
-    auto F = new oox::var<int>[MAX_LEN+1][MAX_LEN+1];
-    oox::var<int> zero(0);
-    auto f = [x,y,xlen,ylen](int i, int j, int F11, int F01, int F10) {
-        return x[i-1]==y[j-1] ? F11+1 : std::max(F01, F10);
-    };
-
-    for( size_t i=1; i<=xlen; ++i )
-        for( size_t j=1; j<=ylen; ++j )
-            F[i][j] = std::move(oox::run(f, i, j, i+j==0?zero:F[i-1][j-1], j==0?zero:F[i][j-1], i==0?zero:F[i-1][j]));
-
-    auto r = oox::wait_and_get(F[xlen][ylen]);
-    delete [] F;
-    return r;
-}}
-
-#if 0
-struct Range2D : tbb::blocked_range2d<int,int> {
-    using tbb::blocked_range2d<int,int>::blocked_range2d;
-    bool is_divisible4() {
-        return rows().is_divisible() && cols().is_divisible();
-    }
-    Range2D quadrant(bool bottom, bool right) {
-        int rmin = rows().begin(), rmax = rows().end(), rmid = (rmin+rmax+1)/2;
-        int cmin = cols().begin(), cmax = cols().end(), cmid = (cmin+cmax+1)/2;
-        return Range2D(bottom?rmid:rmin, bottom?rmax:rmid, rows().grainsize()
-                       ,right?cmid:cmin, right?cmax:cmid, cols().grainsize());
-    }
-};
-namespace SimpleRecursive {
-struct RecursionBody {
-    int (*F)[MAX_LEN+1];
-    const char *X, *Y;
-    RecursionBody(int f[][MAX_LEN+1], const char* x, const char* y) : F(f), X(x), Y(y) {}
-    oox_node operator()(Range2D r) {
-        if( !r.is_divisible4() ) {
-            for( size_t i=r.rows().begin(), ie=r.rows().end(); i<ie; ++i )
-                for( size_t j=r.cols().begin(), je=r.cols().end(); j<je; ++j )
-                    F[i][j] = X[i-1]==Y[j-1] ? F[i-1][j-1]+1 : max(F[i][j-1], F[i-1][j]);
-            return oox_node();
-        }
-        oox_node node00 = oox::run( *this, r.quadrant(0,0) );
-        oox_node node10 = oox::run( *this, r.quadrant(1,0), node00 );
-        oox_node node01 = oox::run( *this, r.quadrant(0,1), node00 );
-        return oox::run( *this, r.quadrant(1,1), node10, node01 );
-    }
-};
-void LCS( const char* x, size_t xlen, const char* y, size_t ylen ) {
-    int F[MAX_LEN+1][MAX_LEN+1];
-    RecursionBody rf(F, x, y);
-
-    oox::wait_and_get( rf(Range2D(0,xlen,0,ylen)) );
-}}
-#endif
-
-}//namespace Wavefront_LCS
 
 #if OOX_SERIAL_DEBUG
 #define OOX OOX_SQ
@@ -231,12 +63,11 @@ TEST(OOX, Simple) {
     ASSERT_EQ(b.get(), 6);
 }
 TEST(OOX, DISABLED_Empty) { // TODO!
-    oox::var<int> a;
+    oox::var<int> a; // TODO: = oox::deferred;
     oox::var<int> b = oox::run(plus, 1, a);
-    //a = 2;
-    // optional, future, ref?
-    ASSERT_EQ(oox::wait_and_get(a), 0);
-    ASSERT_EQ(oox::wait_and_get(b), 1);
+    oox::run([](int &A){ A = 2; }, a); // TODO: define another assignment operator rule?
+    ASSERT_EQ(oox::wait_and_get(a), 2);
+    ASSERT_EQ(oox::wait_and_get(b), 3);
 }
 TEST(OOX, Arch) {
     int arch = ArchSample::test();
@@ -248,15 +79,22 @@ TEST(OOX, Fib) {
 #else
     int x = 25;
 #endif
-    int fib0 = Fib0::Fib(x);
-    int fib1 = oox::wait_and_get(Fib1::Fib(x));
-    int fib2 = oox::wait_and_get(Fib2::Fib(x));
+    using namespace Fibonacci;
+    int fib0 = Serial::Fib(x);
+    int fib1 = oox::wait_and_get(OOX1::Fib(x));
+    int fib2 = oox::wait_and_get(OOX2::Fib(x));
     ASSERT_TRUE(fib0 == fib1 && fib1 == fib2);
 }
 TEST(OOX, FS) {
     int files0 = Filesystem::Serial::disk_usage(Filesystem::tree[0]);
     int files1 = oox::wait_and_get(Filesystem::Simple::disk_usage(Filesystem::tree[0]));
     ASSERT_EQ(files0, files1);
+#ifdef HAVE_TBB
+    int files2 = oox::wait_and_get(Filesystem::AntiDependence::disk_usage(Filesystem::tree[0]));
+    //int files3 = oox::wait_and_get(Filesystem::Extended::disk_usage(Filesystem::tree[0]));
+    ASSERT_EQ(files0, files2);
+    //ASSERT_EQ(files0, files3);
+#endif
 }
 TEST(OOX, Wavefront) {
     using namespace Wavefront_LCS;


### PR DESCRIPTION
re-exported oox::node, refactored examples out to separate files, extended examples and benches - faster TBB bench and adding task_group way